### PR TITLE
Dev

### DIFF
--- a/lib/workflower/acts_as_workflower.rb
+++ b/lib/workflower/acts_as_workflower.rb
@@ -48,11 +48,11 @@ module Workflower
         @allowed_transitions ||= @workflower_base.allowed_transitions
       end
 
-      def workflower_uninitializer
+      def workflower_uninitializer(reset_source_workflow_instance: false)
         @workflower_base.uninitialize
         @workflower_base = nil
 
-        @source_workflow_instance = nil
+        @source_workflow_instance = nil if reset_source_workflow_instance
         @possible_events     = nil
         @allowed_events      = nil
         @allowed_transitions = nil
@@ -83,9 +83,9 @@ module Workflower
       end
 
       def workflower_abilities(workflow_selector: nil)
-        # workflow_selector helps dynamic transition selection when we have multiple workflows that needs to change depending on the selector.
+        # workflow_selector helps dynamic transition selection when we have multiple workflows that needs to change depending on the workflow_selector.
         load = source.new(new).get_workflows.values.flatten.uniq unless workflow_selector.present?
-        load = source.new(selector.to_sym).get_workflows.values.flatten.uniq if selector.present? 
+        load = source.new(workflow_selector.to_sym).get_workflows.values.flatten.uniq if workflow_selector.present? 
 
         unless load.blank?
           # transitions = load.transitions.where("(metadata->>'roles') IS NOT NULL")

--- a/lib/workflower/acts_as_workflower.rb
+++ b/lib/workflower/acts_as_workflower.rb
@@ -9,7 +9,7 @@ module Workflower
       # mattr_accessor :workflower_base
       attr_accessor :possible_events, :allowed_events, :allowed_transitions, :workflow_transition_event_name, :workflow_transition_flow
 
-      def set_intial_state
+      def set_initial_state
         write_attribute self.class.workflower_state_column_name, workflower_initial_state
       end
 
@@ -52,9 +52,10 @@ module Workflower
         @workflower_base.uninitialize
         @workflower_base = nil
 
-        @possible_events     = []
-        @allowed_events      = []
-        @allowed_transitions = []
+        @source_workflow_instance = nil
+        @possible_events     = nil
+        @allowed_events      = nil
+        @allowed_transitions = nil
       end
 
       def initialize(*)
@@ -78,7 +79,7 @@ module Workflower
         self.default_workflow_id          = default_workflow_id
 
         # self.validates  "#{workflow_model.tableize.singularize}_id", presence: true
-        before_create :set_intial_state unless skip_setting_initial_state
+        before_create :set_initial_state unless skip_setting_initial_state
       end
 
       def workflower_abilities(workflow_selector: nil)

--- a/lib/workflower/acts_as_workflower.rb
+++ b/lib/workflower/acts_as_workflower.rb
@@ -81,8 +81,10 @@ module Workflower
         before_create :set_intial_state unless skip_setting_initial_state
       end
 
-      def workflower_abilities
-        load = source.new(new).get_workflows.values.flatten.uniq
+      def workflower_abilities(workflow_selector: nil)
+        # workflow_selector helps dynamic transition selection when we have multiple workflows that needs to change depending on the selector.
+        load = source.new(new).get_workflows.values.flatten.uniq unless workflow_selector.present?
+        load = source.new(selector.to_sym).get_workflows.values.flatten.uniq if selector.present? 
 
         unless load.blank?
           # transitions = load.transitions.where("(metadata->>'roles') IS NOT NULL")


### PR DESCRIPTION
**An example of simple dynamic workflow support.**

- [ ] Setting attr_accessors to `[]` such as `@allowed_transitions = []` will be useless while doing `workflower_uninitializer`, because the next time we say workflower_initializer, This `@allowed_transitions ||= @workflower_base.allowed_transitions` will return `[]`, but if you set it to nil, then it will take the right side value.
- [ ] The same goes with `@source_workflow_instance`, If we don't set it to nil its like that re-initialization never happened.